### PR TITLE
Fix memory leak in network request tracking

### DIFF
--- a/background.js
+++ b/background.js
@@ -312,6 +312,9 @@ class SurveillanceAnalyzer {
       method: details.method,
       type: details.type
     });
+
+    // Prevent unbounded growth of stored requests
+    this.cleanupNetworkRequests();
   }
 
   analyzeResponse(details) {
@@ -345,6 +348,14 @@ class SurveillanceAnalyzer {
         tabId: details.tabId,
         fingerprinting
       });
+    }
+  }
+
+  cleanupNetworkRequests(limit = 1000) {
+    if (this.networkRequests.size > limit) {
+      const excess = this.networkRequests.size - limit;
+      const keys = Array.from(this.networkRequests.keys()).slice(0, excess);
+      keys.forEach(key => this.networkRequests.delete(key));
     }
   }
 


### PR DESCRIPTION
## Summary
- keep only recent network request history to avoid unbounded growth

## Testing
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_686a93262d64832aac9a70129e8eca98